### PR TITLE
fix for .NET Core benchmakrs

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!-- Location of moq packages -->
+    <add key="moq" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/benchmarks/SolrExpress.Core.Benchmarks/Query/SolrQueryableBenchmarks.cs
+++ b/benchmarks/SolrExpress.Core.Benchmarks/Query/SolrQueryableBenchmarks.cs
@@ -10,10 +10,10 @@ namespace SolrExpress.Core.Benchmarks.Query
 {
     public class SolrQueryableBenchmarks
     {
-        private SolrQueryable<TestDocument> _solrQueryable10;
-        private SolrQueryable<TestDocument> _solrQueryable100;
-        private SolrQueryable<TestDocument> _solrQueryable500;
-        private SolrQueryable<TestDocument> _solrQueryable1000;
+        private SolrQueryable<TestDocument> _solrQueryable;
+
+        [Params(10, 100, 500, 1000)]
+        public int ElementsCount { get; set; }
 
         [Setup]
         public void Setup()
@@ -30,7 +30,7 @@ namespace SolrExpress.Core.Benchmarks.Query
             mockResolver.Setup(q => q.GetInstance<ISystemParameter>()).Returns(new Mock<ISystemParameter>().Object);
             mockResolver.Setup(q => q.GetInstance<IParameterContainer>()).Returns(new Mock<IParameterContainer>().Object);
 
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < ElementsCount; i++)
             {
                 var parameterMock = new Mock<IParameter<object>>();
                 parameterMock.Setup(q => q.AllowMultipleInstances).Returns(true);
@@ -39,59 +39,19 @@ namespace SolrExpress.Core.Benchmarks.Query
                 parameters.Add(parameterMock.Object);
             }
             
-            this._solrQueryable10 = new SolrQueryable<TestDocument>(mockProvider.Object, mockResolver.Object, configuration);
-            this._solrQueryable100 = new SolrQueryable<TestDocument>(mockProvider.Object, mockResolver.Object, configuration);
-            this._solrQueryable500 = new SolrQueryable<TestDocument>(mockProvider.Object, mockResolver.Object, configuration);
-            this._solrQueryable1000 = new SolrQueryable<TestDocument>(mockProvider.Object, mockResolver.Object, configuration);
+            _solrQueryable = new SolrQueryable<TestDocument>(mockProvider.Object, mockResolver.Object, configuration);
 
-            this._solrQueryable10.Parameter(parameters.Take(10).ToArray());
-            this._solrQueryable100.Parameter(parameters.Take(100).ToArray());
-            this._solrQueryable500.Parameter(parameters.Take(500).ToArray());
-            this._solrQueryable1000.Parameter(parameters.ToArray());
+            _solrQueryable.Parameter(parameters.Take(ElementsCount).ToArray());
         }
 
         /// <summary>
         /// Where   Using a SolrQueryable instance
         /// When    Invoking the method "Execute"
-        /// With    Using 10 parameters
-        /// </summary>
-        [Benchmark(Baseline = true)]
-        public void SolrQueryableWith10Parameters()
-        {
-            var result = this._solrQueryable10.Execute();
-        }
-
-        /// <summary>
-        /// Where   Using a SolrQueryable instance
-        /// When    Invoking the method "Execute"
-        /// With    Using 100 parameters
-        /// </summary>
-        [Benchmark(Baseline = true)]
-        public void SolrQueryableWith100Parameters()
-        {
-            var result = this._solrQueryable100.Execute();
-        }
-
-        /// <summary>
-        /// Where   Using a SolrQueryable instance
-        /// When    Invoking the method "Execute"
-        /// With    Using 500 parameters
-        /// </summary>
-        [Benchmark(Baseline = true)]
-        public void SolrQueryableWith500Parameters()
-        {
-            var result = this._solrQueryable500.Execute();
-        }
-
-        /// <summary>
-        /// Where   Using a SolrQueryable instance
-        /// When    Invoking the method "Execute"
-        /// With    Using 1000 parameters
         /// </summary>
         [Benchmark]
-        public void SolrQueryableWith1000Parameters()
+        public QueryResult<TestDocument> SolrQueryable()
         {
-            var result = this._solrQueryable1000.Execute();
+            return _solrQueryable.Execute();
         }
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-  "projects": [ "src" ]
+  "projects": [ "src", "benchmarks" ]
 }


### PR DESCRIPTION
Hi @diegobrum 

I was able to reproduce your problem, the reason was incomplete `global.json` file

Hope you enjoy,
Adam 