### PR TITLE
Remove commas for dist and sudo keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
-dist: trusty,
-sudo: required,
+dist: trusty
+sudo: required
 dotnet: 1.0.0-preview3-004056
 solution: SolrExpress.sln
 os: osx


### PR DESCRIPTION
Hi!

I work at travis and saw this repo pop up in our error logs, looks like the comma at the end of these two lines is preventing the build from starting correctly.

I hope this PR helps fix that!