### PR TITLE
#211 Fix for using post method (Update/insert documents)

### DIFF
--- a/src/SolrExpress.Solr5/SolrConnection.cs
+++ b/src/SolrExpress.Solr5/SolrConnection.cs
@@ -78,7 +78,7 @@ namespace SolrExpress.Solr5
             this.SetAuthentication(options, url);
 
             return url
-                .PostJsonAsync(data)
+                .PostJsonAsync(JsonConvert.DeserializeObject(data))
                 .ReceiveString()
                 .Result;
         }


### PR DESCRIPTION
The data obtained from the atomic update is raw data. Which means this still needs to be deserialized to be a valid json string. This exact behaviour is also done within the get method. Making select queries work again.

Closes #211 